### PR TITLE
Updated for modern Node.js runtimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
+  - "10"
+  - "12"
+  - "13"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "8"
   - "10"
   - "12"
   - "13"

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ function encrypt(key, plaintext) {
     i = -1;
     while (++i < n) {
       b = enc.encrypt(a, r[i]);
-      t.writeBigUInt64BE(BigInt((n * j) + i + 1), 0);
+      t.writeUInt32BE(0, 0);
+      t.writeUInt32BE((n * j) + i + 1, 4);
       a = xor(msb(b), t);
       r[i] = lsb(b);
     }
@@ -77,7 +78,8 @@ function decrypt(key, ciphertext) {
   while (--j >= 0) {
     i = n;
     while (--i) {
-      t.writeBigUInt64BE(BigInt(((n - 1)* j) + i), 0);
+      t.writeUInt32BE(0, 0);
+      t.writeUInt32BE(((n - 1)* j) + i, 4);
       a = xor(a, t);
       b = enc.encrypt(a, r[i]);
       a = msb(b);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "node test.js"
   },
+  "engines": {
+    "node": ">=10.4.0"
+  },
   "author": "Calvin Metcalf <calvin.metcalf@gmail.com>",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node test.js"
   },
   "engines": {
-    "node": ">=10.4.0"
+    "node": ">=8.0.0"
   },
   "author": "Calvin Metcalf <calvin.metcalf@gmail.com>",
   "license": "MIT",

--- a/test.js
+++ b/test.js
@@ -42,9 +42,9 @@ test('it works', function (t) {
 function testIt(t, i) {
   t.test('vector:' + i, function (t) {
     t.plan(2);
-    var key = new Buffer(vectors[i].key.replace(/\s/g, ''), 'hex');
-    var plaintext = new Buffer(vectors[i].plaintext.replace(/\s/g, ''), 'hex');
-    var ciphertext = new Buffer(vectors[i].ciphertext.replace(/\s/g, ''), 'hex');
+    var key = Buffer.from(vectors[i].key.replace(/\s/g, ''), 'hex');
+    var plaintext = Buffer.from(vectors[i].plaintext.replace(/\s/g, ''), 'hex');
+    var ciphertext = Buffer.from(vectors[i].ciphertext.replace(/\s/g, ''), 'hex');
     var encrypted = kw.encrypt(key, plaintext);
     t.equals(encrypted.toString('hex'), ciphertext.toString('hex'), 'encrypts');
     var decrypted = kw.decrypt(key, ciphertext);


### PR DESCRIPTION
The code was not working on Node.js 12, causing exceptions. I've updated it so it now supports recent Node.js versions (from Node.js 8 and higher)

(First commit used BigInt and certain methods not available until Node.js 12; I've changed that in the second commit)